### PR TITLE
Speedup day12 by a factor of 2 using symmetry

### DIFF
--- a/src/days/day12.rs
+++ b/src/days/day12.rs
@@ -45,12 +45,15 @@ fn lcm(a: usize, b: usize, c: usize) -> usize {
 }
 
 fn find_period(initial_state: Vec<Moon>, mut moons: Vec<Moon>) -> usize {
-    for i in 1001.. {
+    'outer: for i in 1001.. {
         step(&mut moons);
 
-        if initial_state == moons {
-            return i;
+        for moon in &moons {
+            if moon.vel != 0 {
+                continue 'outer;
+            }
         }
+        return i * 2;
     }
     unreachable!();
 }

--- a/src/days/day12.rs
+++ b/src/days/day12.rs
@@ -49,7 +49,11 @@ fn find_period(initial_state: Vec<Moon>, mut moons: Vec<Moon>) -> usize {
         step(&mut moons);
 
         if moons.iter().all(|moon| moon.vel == 0) {
-            return i * 2;
+            if moons == initial_state {
+                return i;
+            } else {
+                return i * 2;
+            }
         }
     }
     unreachable!();

--- a/src/days/day12.rs
+++ b/src/days/day12.rs
@@ -45,15 +45,12 @@ fn lcm(a: usize, b: usize, c: usize) -> usize {
 }
 
 fn find_period(initial_state: Vec<Moon>, mut moons: Vec<Moon>) -> usize {
-    'outer: for i in 1001.. {
+    for i in 1001.. {
         step(&mut moons);
 
-        for moon in &moons {
-            if moon.vel != 0 {
-                continue 'outer;
-            }
+        if moons.iter().all(|moon| moon.vel == 0) {
+            return i * 2;
         }
-        return i * 2;
     }
     unreachable!();
 }


### PR DESCRIPTION
The period of the moons orbits is always even because the moons start out stationary. If you consider the physics going forward an backwards you will find the same points at each timestep until you reach the halfway point which will also be stationary.

To exploit this just check if velocities are 0 and if they are you can multiply the step count and get the total period for an axis.